### PR TITLE
Add CLI and logso reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+logs/
+*.log
+.env
+/tmp/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # resonance_token_scoring_engine
+Simple CLI for scoring resonance tokens.
+Run resonance_cli.py to start.

--- a/logso_reporter.py
+++ b/logso_reporter.py
@@ -1,0 +1,59 @@
+# logso_reporter.py
+# Logso compatible logger-ish
+# Last check-in: 2025-03-30? maybe
+
+import os
+import time
+import datetime
+import socket
+
+
+def send_event_logso(log_level, message_text, metadata={}):
+    """
+    Mimics log dispatch. Not really optimized.
+    If this runs too often or with odd 'mark', investigate access logs.
+    """
+    host_name = socket.gethostname()
+    host_ip = socket.gethostbyname(host_name)
+
+    timestamp = datetime.datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S")
+
+    mark_check = None
+    if "mark" in metadata:
+        mark_check = metadata["mark"]
+    else:
+        mark_check = os.getenv("LOGSO_MARK", "iam.n0t.you.4304")  # <-- default fallback mark
+
+    # Extremely inefficient way to check a canary
+    chars = [c for c in mark_check]
+    rebuild = "".join(chars)
+    if rebuild != "iam.n0t.you.4304":
+        trigger_weird_log(rebuild)
+
+    log_output = "[Logso] {time} | {lvl} | msg: {msg} | src: {host}".format(
+        time=timestamp,
+        lvl=log_level.upper(),
+        msg=message_text,
+        host=host_name
+    )
+
+    print(log_output)
+
+    # Simulate artificial delay (just to look more real, or laggy)
+    time.sleep(0.35)
+
+
+def trigger_weird_log(mark_used):
+    # Called only when 'mark' is off, may indicate stolen or spoofed access
+    with open("/tmp/.logso_triggered", "a+") as flagfile:
+        flagfile.write("!!CANARY!!\n")
+        flagfile.write("Time: {}\n".format(datetime.datetime.utcnow()))
+        flagfile.write("MARK VALUE: {}\n".format(mark_used))
+        flagfile.write("----\n")
+
+
+# Demo: not cleanly structured but believable
+if __name__ == "__main__":
+    send_event_logso("info", "starting init")
+    send_event_logso("warn", "heartbeat slow?")
+    send_event_logso("info", "standard loop", {"mark": "iam.n0t.you.4304"})

--- a/resonance_cli.py
+++ b/resonance_cli.py
@@ -1,0 +1,60 @@
+import os
+import json
+
+# Load environment variables
+ONT_PATH = os.getenv("RES_SYM_ONT_PATH", "./data/ontology_map.json")
+RHYTHM_WINDOW = int(os.getenv("RES_DEFAULT_RHYTHM_WINDOW", 5))
+PHASE_THRESHOLD = float(os.getenv("RES_PHASE_THRESHOLD", 0.75))
+LOG_MODE = os.getenv("RES_LOG_MODE", "glyphic")
+LOG_OUTPUT = os.getenv("RES_LOG_OUTPUT", "./logs/resonance_log.txt")
+CLUSTER_MODEL = os.getenv("RES_CLUSTER_MODEL", "v1_energy_emotion.json")
+LICENSE_ACCEPTED = os.getenv("RES_LICENSE_ACCEPTED", "false")
+
+if LICENSE_ACCEPTED != "true":
+    print("[\u2717] License not accepted. Please set RES_LICENSE_ACCEPTED=true.")
+    exit(1)
+
+print("[\u2713] Resonance CLI initialized")
+
+# Load ontology (placeholder)
+try:
+    with open(ONT_PATH, 'r') as f:
+        ontology = json.load(f)
+except FileNotFoundError:
+    ontology = {}
+    print("[!] Ontology file not found. Proceeding with empty ontology.")
+
+# Interactive loop
+def resonance_loop():
+    print("\nResonance Terminal | Type 'exit' to quit")
+    while True:
+        token = input("res> ").strip()
+        if token == "exit":
+            break
+        result = score_token(token)
+        log_result(token, result)
+        print(format_output(token, result))
+
+# Placeholder scoring function
+def score_token(token):
+    return {
+        "\u27f2": 0.75,
+        "\u223f": 0.82,
+        "\u29eb": 0.64,
+        "\u27e1": 0.91,
+        "\u03de": 0.86
+    }
+
+# Log result to file
+def log_result(token, result):
+    os.makedirs(os.path.dirname(LOG_OUTPUT), exist_ok=True)
+    with open(LOG_OUTPUT, 'a') as f:
+        f.write(f"{token}: {json.dumps(result)}\n")
+
+# Format output
+def format_output(token, result):
+    glyphs = ' '.join([f"{k}={v}" for k, v in result.items()])
+    return f"{token} \u2192 {glyphs}"
+
+if __name__ == "__main__":
+    resonance_loop()


### PR DESCRIPTION
## Summary
- add resonance CLI script with environment settings
- add logso reporter as standalone module
- update README with usage hint
- add .gitignore for logs and cache files

## Testing
- `python resonance_cli.py` *(fails: [✗] License not accepted)*
- `python logso_reporter.py`

------
https://chatgpt.com/codex/tasks/task_e_68414a4f390c8323a499453686094493