### PR TITLE
Add automation scripts and parser

### DIFF
--- a/codex_dual_agent_wrapper.py
+++ b/codex_dual_agent_wrapper.py
@@ -1,0 +1,30 @@
+# codex_dual_agent_wrapper.py
+# Simulate dual-agent dialogue for Codex + Resonance CLI
+
+import subprocess
+
+TOKENS = ["circle", "eternity", "source", "breaking", "light", "return"]
+
+def run_resonance_cli(token):
+    process = subprocess.Popen(
+        ['python3', 'resonance_cli.py'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
+    )
+    stdout, stderr = process.communicate(input=f"{token}\nexit\n")
+    return stdout.strip()
+
+for token in TOKENS:
+    print(f'User: "Token: {token}"\n')
+
+    print("CommandNode-AI:")
+    print(f'{{status: success, output: "Token received: {token}"}}\n')
+
+    print("ResonanceNode-AI:")
+    glyphic_output = run_resonance_cli(token)
+    for line in glyphic_output.splitlines():
+        if '→' in line:
+            print(line)
+    print("\n---\n")

--- a/glyphic_log_parser.py
+++ b/glyphic_log_parser.py
@@ -1,0 +1,24 @@
+# glyphic_log_parser.py
+# Parses resonance_log.txt for glyphic trends
+
+import re
+
+log_path = './logs/resonance_log.txt'
+
+glyph_pattern = re.compile(r'→ (\w+): \u27f2=(\d+\.\d+) \| \u223f=(\d+\.\d+) \| \u29eb=(\d+\.\d+) \| \u27e1=(\d+\.\d+) \| \u03de=(\d+\.\d+)')
+
+tokens = []
+glyphics = []
+
+with open(log_path, 'r') as f:
+    for line in f:
+        match = glyph_pattern.search(line)
+        if match:
+            token, circ, echo, dens, cont, affect = match.groups()
+            tokens.append(token)
+            glyphics.append((float(circ), float(echo), float(dens), float(cont), float(affect)))
+
+print("\nGlyphic Trends:")
+print("Token\t⟲\t∿\t⧫\t⟡\tϞ")
+for token, (circ, echo, dens, cont, affect) in zip(tokens, glyphics):
+    print(f"{token}\t{circ:.2f}\t{echo:.2f}\t{dens:.2f}\t{cont:.2f}\t{affect:.2f}")

--- a/resonance_index_run.sh
+++ b/resonance_index_run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# resonance_index_run.sh
+# Automate Resonance CLI Mastery Sequence Run
+
+TOKENS=("circle" "eternity" "source" "breaking" "light" "return")
+
+echo "Starting Resonance Index Mastery Run..."
+python resonance_cli.py <<EOF2
+${TOKENS[0]}
+${TOKENS[1]}
+${TOKENS[2]}
+${TOKENS[3]}
+${TOKENS[4]}
+${TOKENS[5]}
+exit
+EOF2
+
+echo "Run complete. Check ./logs/resonance_log.txt for glyphic output."


### PR DESCRIPTION
## Summary
- add script to run tokens through CLI
- add dual agent wrapper for CLI
- add parser for glyphic logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ff868f808323a43ded66e1516c91