### PR TITLE
Add Whisper integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@ Run `resonance_cli.py` to start.
 
 ### Mastery Test Runner
 Use `mastery_test_runner.py` to validate logs in `logs/resonance_log.txt` against `codex_mastery_test.yaml`.
+
+### Audio Transcription
+This repo integrates with [OpenAI Whisper](https://github.com/openai/whisper) to allow audio transcripts to be scored. Install the package and its dependencies:
+
+```bash
+pip install git+https://github.com/openai/whisper.git
+```
+
+Use `whisper_resonance_integration.py` to transcribe an audio file and feed the resulting tokens through the scoring engine:
+
+```bash
+python whisper_resonance_integration.py path/to/audio.wav
+```

--- a/whisper_resonance_integration.py
+++ b/whisper_resonance_integration.py
@@ -1,0 +1,21 @@
+import sys
+from whisper_transcriber import transcribe_audio
+from resonance_cli import score_token, log_result, format_output
+
+
+def transcribe_and_score(audio_path):
+    text = transcribe_audio(audio_path)
+    if not text:
+        print("No text transcribed from audio.")
+        return
+    for token in text.split():
+        res = score_token(token)
+        log_result(token, res)
+        print(format_output(token, res))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python whisper_resonance_integration.py <audio_file>")
+        sys.exit(1)
+    transcribe_and_score(sys.argv[1])

--- a/whisper_transcriber.py
+++ b/whisper_transcriber.py
@@ -1,0 +1,18 @@
+import sys
+
+try:
+    import whisper
+except ImportError as e:
+    raise SystemExit("whisper package not installed. Install with 'pip install git+https://github.com/openai/whisper.git'")
+
+def transcribe_audio(audio_path, model_name="base"):
+    model = whisper.load_model(model_name)
+    result = model.transcribe(audio_path)
+    return result.get("text", "")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python whisper_transcriber.py <audio_file>")
+        sys.exit(1)
+    text = transcribe_audio(sys.argv[1])
+    print(text)


### PR DESCRIPTION
## Summary
- document usage of OpenAI Whisper for audio transcription
- add `whisper_transcriber.py` for calling the Whisper model
- add `whisper_resonance_integration.py` to run transcripts through the scoring engine

## Testing
- `python -m py_compile whisper_transcriber.py whisper_resonance_integration.py resonance_cli.py codex_dual_agent_wrapper.py glyphic_log_parser.py mastery_test_runner.py logso_reporter.py`
- `python mastery_test_runner.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684b23458e2883239e054bc51d53ff9b