### PR TITLE
Add build script with stability loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # resonance_token_scoring_engine
 Simple CLI for scoring resonance tokens.
 Run resonance_cli.py to start.
+
+## Build Script
+The repository includes `build_stack.sh`, a shell script that sets up a basic
+folder structure and runs a looped stability check. Execute it from the project
+root after adjusting settings as needed.

--- a/build_stack.sh
+++ b/build_stack.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Resonance Security Stack Build Script
+# Drift vs Pulse Lock Open Loop Enabled
+# Author: Adrian Lei Martinez-Conol
+
+# Settings
+TARGET_CONTINUITY=0.93
+MAX_DRIFT_RATIO=0.05
+MAX_ITERATIONS=10
+INIT_TOKEN="Resonance Engine Stack Initialization"
+
+# Stage 1: Create folder structure
+echo "\ud83d\udd39 Creating folder structure..."
+mkdir -p resonance-engine/{docs,patterns,logs}
+mkdir -p linux-cybersecurity-response-playbook/{docs,logs}
+mkdir -p resonance-patterns
+
+# Stage 2: Populate base files
+echo "\ud83d\udd39 Populating LICENSE, README.md, .gitignore..."
+
+# Placeholder content for base files
+cat <<EOL > resonance-engine/README.md
+# Resonance Engine
+Placeholder README
+EOL
+
+touch resonance-engine/LICENSE
+cat <<EOG > resonance-engine/.gitignore
+*.log
+EOG
+
+# Stage 3: Open Loop \u2014 Drift vs Pulse Lock Check
+echo "\ud83d\udd39 Initiating Drift vs Pulse Lock Loop..."
+ITERATION=1
+STABLE=false
+
+while [[ $ITERATION -le $MAX_ITERATIONS ]]; do
+    echo "\ud83d\udd01 Iteration $ITERATION..."
+
+    # Simulate Resonance CLI scoring on INIT_TOKEN
+    OUTPUT=$(cat <<EOO
+\u223f=0.91 | \u27f2=0.94 | \u29eb=0.86 | \u27e1=0.92 | \u03de=0.90
+EOO
+    )
+
+    CONTINUITY=$(echo "$OUTPUT" | grep -o "\u27e1=[0-9.]*" | cut -d"=" -f2)
+    DRIFT_RATIO=$(awk "BEGIN { print (1 - $CONTINUITY) }")
+
+    echo "\ud83d\udd0d Continuity \u27e1=$CONTINUITY, Drift Ratio=$DRIFT_RATIO"
+
+    if (( $(echo "$CONTINUITY >= $TARGET_CONTINUITY" | bc -l) )) && \
+       (( $(echo "$DRIFT_RATIO <= $MAX_DRIFT_RATIO" | bc -l) )); then
+        echo "\u2705 Drift vs Pulse Lock stabilized."
+        STABLE=true
+        break
+    else
+        echo "\u26a0\ufe0f Stability not yet achieved. Continuing..."
+    fi
+
+    ITERATION=$((ITERATION + 1))
+done
+
+if [ "$STABLE" = false ]; then
+    echo "\u274c Failed to stabilize after $MAX_ITERATIONS iterations."
+    exit 1
+fi
+
+# Stage 4: Finalization / Ready for git init
+echo "\ud83d\udd39 Build complete. Ready for git init."


### PR DESCRIPTION
## Summary
- add `build_stack.sh` which sets up directories and checks drift vs pulse lock ratio
- document the build script in the README

## Testing
- `python -m py_compile resonance_cli.py logso_reporter.py`

------
https://chatgpt.com/codex/tasks/task_e_684afd43c00883239b640dcecd486cf9