### PR TITLE
Handle missing PyYAML

### DIFF
--- a/mastery_test_runner.py
+++ b/mastery_test_runner.py
@@ -1,7 +1,11 @@
 # mastery_test_runner.py
 # Auto-validate Resonance Token Mastery Sequence against codex_mastery_test.yaml
 
-import yaml
+try:
+    import yaml
+except ImportError as e:
+    print("[!] PyYAML is required to run this script. Install it via 'pip install PyYAML'.")
+    raise SystemExit(e)
 import re
 
 LOG_PATH = './logs/resonance_log.txt'


### PR DESCRIPTION
## Summary
- catch `ImportError` when loading PyYAML in `mastery_test_runner`
- instruct users to install the `PyYAML` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b97deec448323b1e679c075fc8abc