### PR TITLE
Add shebang and license references

### DIFF
--- a/codex_dual_agent_wrapper.py
+++ b/codex_dual_agent_wrapper.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License 2.0
 # codex_dual_agent_wrapper.py
 # Simulate dual-agent dialogue for Codex + Resonance CLI
 

--- a/glyphic_log_parser.py
+++ b/glyphic_log_parser.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License 2.0
 # glyphic_log_parser.py
 # Parses resonance_log.txt for glyphic trends
 

--- a/logso_reporter.py
+++ b/logso_reporter.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License 2.0
 # logso_reporter.py
 # Logso compatible logger-ish
 # Last check-in: 2025-03-30? maybe

--- a/mastery_test_runner.py
+++ b/mastery_test_runner.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License 2.0
 # mastery_test_runner.py
 # Auto-validate Resonance Token Mastery Sequence against codex_mastery_test.yaml
 

--- a/resonance-engine/resonance_cli.py
+++ b/resonance-engine/resonance_cli.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License 2.0
 import os
 import json
 

--- a/resonance-engine/resonance_index.py
+++ b/resonance-engine/resonance_index.py
@@ -1,1 +1,3 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License 2.0
 # Placeholder for resonance index logic

--- a/resonance-engine/resonance_token_engine.py
+++ b/resonance-engine/resonance_token_engine.py
@@ -1,1 +1,3 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License 2.0
 # Placeholder for resonance token engine implementation

--- a/resonance_cli.py
+++ b/resonance_cli.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License 2.0
 import os
 import json
 


### PR DESCRIPTION
## Summary
- add a Python 3 shebang to all scripts
- mention Apache License 2.0 below each shebang

## Testing
- `python3 -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b97dbf4288323839fa62c01caaacd